### PR TITLE
Add peek(key)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 coverage
+/yarn.lock

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ There are a few basic things that all caches support.
     If `recordStats` is set to `false`, then the get won't increase any metrics
     or affect any stats of a bounded cache.
 
+* `cache.peek(key): mixed|null`
+
+    Same as `getIfPresent(key, false)`. Will return the cached value, but never
+		load a value if it does not exist and not affect any metrics or stats of
+		the cache.
+
 * `cache.has(key): boolean`
 
     Check if the given key exists in the cache. The key can be either a

--- a/README.md
+++ b/README.md
@@ -48,10 +48,12 @@ There are a few basic things that all caches support.
     Get a cached value. The key can be either a string or a number. Will return
     any cached value and update is usage frequency.
 
-* `cache.getIfPresent(key): mixed|null`
+* `cache.getIfPresent(key, [recordStats]): mixed|null`
 
     Same as `get(key)` except this will never load a value if it does not exist.
     Usually used together with a loading cache to bypass loading if not needed.
+    If `recordStats` is set to `false`, then the get won't increase any metrics
+    or affect any stats of a bounded cache.
 
 * `cache.has(key): boolean`
 

--- a/cache/base.js
+++ b/cache/base.js
@@ -17,6 +17,10 @@ module.exports = class BaseCache {
 		throwError();
 	}
 
+	peek(key) {
+		return this.getIfPresent(key, false);
+	}
+
 	delete(key) {
 		throwError();
 	}

--- a/cache/base.js
+++ b/cache/base.js
@@ -13,7 +13,7 @@ module.exports = class BaseCache {
 		throwError();
 	}
 
-	getIfPresent(key) {
+	getIfPresent(key, recordStats=true) {
 		throwError();
 	}
 

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -22,6 +22,11 @@ describe('BaseCache', function() {
 		expect(() => cache.getIfPresent('key')).to.throw();
 	});
 
+	it('peek throws', function() {
+		const cache = new BaseCache();
+		expect(() => cache.peek('key')).to.throw();
+	});
+
 	it('delete throws', function() {
 		const cache = new BaseCache();
 		expect(() => cache.delete('key')).to.throw();

--- a/test/bounded.test.js
+++ b/test/bounded.test.js
@@ -16,6 +16,7 @@ describe('BoundedCache', function() {
 
 		expect(cache.has('key')).to.equal(true);
 		expect(cache.get('key')).to.equal('value');
+		expect(cache.peek('key')).to.equal('value');
 	});
 
 	it('Get non-existent value in cache', function() {

--- a/test/metrics.test.js
+++ b/test/metrics.test.js
@@ -44,4 +44,14 @@ describe('MetricsCache', function() {
 		expect(cache.metrics.misses).to.equal(0);
 		expect(cache.metrics.hitRate).to.equal(1);
 	});
+
+	it('Peek without recording stats', function() {
+		const cache = newCache();
+
+		expect(cache.peek('key')).to.equal(null);
+
+		expect(cache.metrics.hits).to.equal(0);
+		expect(cache.metrics.misses).to.equal(0);
+		expect(cache.metrics.hitRate).to.equal(1);
+	});
 });


### PR DESCRIPTION
As a shortcut to `getIfPresent(key, false)` – mimicking eg. https://www.npmjs.com/package/lru-cache#api

Also: Document `getIfPresent(key, false)`

And as an added bonus: Ignore `yarn.lock`