### PR TITLE
Loading Cache with expire after write can return an incorrect result.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "transitory",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitory",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "In-memory cache with high hit rates via LFU eviction. Supports time-based expiration, automatic loading and metrics.",
   "license": "MIT",
   "repository": "aholstenson/transitory",

--- a/src/cache/loading/index.ts
+++ b/src/cache/loading/index.ts
@@ -40,8 +40,9 @@ export class DefaultLoadingCache<K extends KeyType, V> extends WrappedCache<K, V
 	}
 
 	public get(key: K, loader?: Loader<K, V>): Promise<V> {
-		if(this.has(key)) {
-			return Promise.resolve(this.getIfPresent(key) as V);
+		const valueIfAlreadyPresent = this.getIfPresent(key);
+		if (valueIfAlreadyPresent != null) {
+			return Promise.resolve(valueIfAlreadyPresent as V);
 		}
 
 		const data = this[DATA];

--- a/test/dateRolloverFix.test.ts
+++ b/test/dateRolloverFix.test.ts
@@ -1,0 +1,47 @@
+import { CacheBuilderImpl } from '../src/builder/unified-builder';
+
+const uuidCacheExpireAfterWrite: number = 3000;// 3 seconds
+
+describe('Cache testing', () => {
+	const RealDate = Date.now;
+	let date: number = Date.now();
+
+	afterAll(() => {
+		global.Date.now = RealDate;
+	});
+
+	function setNow() {
+		global.Date.now = jest.fn(() => date++);
+	}
+
+	test('Cache timing out relead test', () => {
+		/*
+		 * A problem was discoverd in the Expiration cache where the code executed
+		 * if(this.has(key)) {return Promise.resolve(this.getIfPresent(key) as V); }
+		 * Both the calls to has() and getIfPresent() read the Date.now() value to see
+		 * if the entry has expired. The problem occured when Date.now() returned the
+		 * next value for the second call - the clock had moved on - and the entry had
+		 * become timed out.
+		 * This test simulates that condition by mocking the Date.now() function.
+		 */
+		const testCache = new CacheBuilderImpl<string, boolean>()
+			.maxSize(200)
+			.withLoader(uuid => cacheLoader(uuid))
+			.expireAfterWrite(uuidCacheExpireAfterWrite)
+			.build();
+		setNow();
+		const myKey: string = 'fred';
+		testCache.set(myKey, true);
+		// Set date to the millisecond before timeout so that it times out on the second
+		// read within testCache.get().
+		date = date + uuidCacheExpireAfterWrite - 1;
+		return (testCache.get(myKey))
+			.then((result: boolean) => {
+				expect(result).toBeTruthy();
+			});
+	});
+});
+
+function cacheLoader(val: any): Promise<boolean> {
+	return Promise.resolve(true);
+}

--- a/test/dateRolloverFix.test.ts
+++ b/test/dateRolloverFix.test.ts
@@ -16,7 +16,7 @@ describe('Cache testing', () => {
 
 	test('Cache timing out relead test', () => {
 		/*
-		 * A problem was discoverd in the Expiration cache where the code executed
+		 * A problem was discoverd in the Loading cache where the code executed
 		 * if(this.has(key)) {return Promise.resolve(this.getIfPresent(key) as V); }
 		 * Both the calls to has() and getIfPresent() read the Date.now() value to see
 		 * if the entry has expired. The problem occured when Date.now() returned the


### PR DESCRIPTION
Issue #122 

The code for the get method in the Loading cache contains the code:

> if (this.has(key)) {return Promise.resolve(this.getIfPresent(key) as V); }

The problem is that both has() and getIfPresent() call Date.now() to see if the item has expired. If Date.now() rolls over between these two calls, the one may decide that the entry is still valid, the second that it is not. This results in null being returned to the user.

I have created a new test which demonstrates the fault. I checked that in.
I then updated the code as per my suggestion in the issue; re-ran the tests and checked that everything now passes.